### PR TITLE
[GET] The framing process can obtain the context from the endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 validators
 sparqltransformer==1.6.10
-SPARQLWrapper @ git+https://github.com/sirspock/sparqlwrapper.git@1.8.6#egg=SPARQLWrapper
+SPARQLWrapper_sirspock @ git+https://github.com/sirspock/sparqlwrapper.git@1.8.6#egg=SPARQLWrapper
 pythonql3==0.9.61
 pyaml==18.11.0
 rdflib-jsonld==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 validators
+sparqltransformer==1.6.10
 SPARQLWrapper @ git+https://github.com/sirspock/sparqlwrapper.git@1.8.6#egg=SPARQLWrapper
 pythonql3==0.9.61
 pyaml==18.11.0
@@ -7,7 +8,6 @@ rdflib==4.2.2
 requests>=2.20.0
 simplejson==3.16.0
 six==1.11.0
-sparqltransformer==1.6.10
 urllib3==1.24.3
 webencodings==0.5.1
 werkzeug>=0.15.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 validators
 sparqltransformer==1.6.10
-SPARQLWrapper_sirspock @ git+https://github.com/sirspock/sparqlwrapper.git@1.8.6#egg=SPARQLWrapper
 pythonql3==0.9.61
 pyaml==18.11.0
 rdflib-jsonld==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 validators
-SPARQLWrapper
+SPARQLWrapper @ git+https://github.com/sirspock/sparqlwrapper.git@1.8.6#egg=SPARQLWrapper
 pythonql3==0.9.61
 pyaml==18.11.0
 rdflib-jsonld==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,8 @@ setup(
     packages=["obasparql"],
     include_package_data=True,
     install_requires=install_requires,
+
+    dependency_links=[
+        'git+https://github.com/sirspock/sparqlwrapper.git@1.8.6#egg=SPARQLWrapper'
+    ]
 )

--- a/test/test_dispatch_sparql_query_model_catalog.py
+++ b/test/test_dispatch_sparql_query_model_catalog.py
@@ -107,14 +107,32 @@ class TestQueryManager(unittest.TestCase):
         owl_class_uri = "https://w3id.org/okn/o/sdm#Region"
         owl_resource_uri = "https://w3id.org/okn/i/mint/United_States"
         response = '''{
-  "@id" : "https://w3id.org/okn/i/mint/United_States",
-  "@type" : "https://w3id.org/okn/o/sdm#Region",
-  "label" : "United States of America",
-  "description" : "The United States of America (U.S.A. or USA), commonly known as the United States (U.S. or US) or America, is a country comprising 50 states, a federal district, five major self-governing territories, and various possessions. At 3.8 million square miles (9.8 million km2), the United States is the world's third or fourth largest country by total area and is slightly smaller than the entire continent of Europe. With a population of over 327 million people, the U.S. is the third most populous country. The capital is Washington, D.C., and the most populous city is New York City. Most of the country is located contiguously in North America between Canada and Mexico.",
-  "partOf" : "https://w3id.org/okn/i/mint/America",
+  "@graph" : [ {
+    "@id" : "https://w3id.org/okn/i/mint/Texas",
+    "@type" : "https://w3id.org/okn/o/sdm#Region",
+    "label" : "Texas (USA)",
+    "description" : "Texas is the second largest state in the United States by area (after Alaska) and population (after California). Located in the South Central region, Texas shares borders with the states of Louisiana to the east, Arkansas to the northeast, Oklahoma to the north, New Mexico to the west, and the Mexican states of Chihuahua, Coahuila, Nuevo Leon, and Tamaulipas to the southwest, and has a coastline with the Gulf of Mexico to the southeast.",
+    "geo" : "https://w3id.org/okn/i/mint/Texas_Shape",
+    "partOf" : "https://w3id.org/okn/i/mint/United_States"
+  }, {
+    "@id" : "https://w3id.org/okn/i/mint/Texas_Shape",
+    "@type" : "https://w3id.org/okn/o/sdm#GeoShape",
+    "label" : "Bounding box for Texas region"
+  }, {
+    "@id" : "https://w3id.org/okn/i/mint/United_States",
+    "@type" : "https://w3id.org/okn/o/sdm#Region",
+    "label" : "United States of America"
+  }, {
+    "@id" : "https://w3id.org/okn/o/sdm#Region",
+    "@type" : "http://www.w3.org/2002/07/owl#Class"
+  } ],
   "@context" : {
     "partOf" : {
       "@id" : "https://w3id.org/okn/o/sdm#partOf",
+      "@type" : "@id"
+    },
+    "geo" : {
+      "@id" : "https://w3id.org/okn/o/sdm#geo",
       "@type" : "@id"
     },
     "description" : {
@@ -123,10 +141,10 @@ class TestQueryManager(unittest.TestCase):
     "label" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#label"
     },
-    "sd" : "https://w3id.org/okn/o/sd#",
     "rdfs" : "http://www.w3.org/2000/01/rdf-schema#"
   }
-}'''
+}
+'''
 
         framed = self.query_manager.frame_results(response, owl_class_uri, owl_resource_uri)
         self.assertEqual(owl_resource_uri, framed[0]["id"])

--- a/test/test_query_dbpedia.py
+++ b/test/test_query_dbpedia.py
@@ -23,7 +23,7 @@ class TestQuery(unittest.TestCase):
         """
         owl_class_name = "Band"
         owl_class_uri = "http://dbpedia.org/ontology/Band"
-        resource_uri = "http://dbpedia.org/resource/Indemnity_Act_1717"
+        resource_uri = "http://dbpedia.org/resource/Pink_Floyd"
         query_type = GET_ONE_QUERY
 
         # grlc args

--- a/test/test_query_manager.py
+++ b/test/test_query_manager.py
@@ -148,12 +148,21 @@ class TestQueryManager(unittest.TestCase):
     def test_framed_get_one_reflexive(self):
         owl_class_uri = "https://w3id.org/okn/o/sdm#Region"
         owl_resource_uri = "https://w3id.org/okn/i/mint/United_States"
-        response = '''{
-  "@id" : "https://w3id.org/okn/i/mint/United_States",
-  "@type" : "https://w3id.org/okn/o/sdm#Region",
-  "label" : "United States of America",
-  "description" : "The United States of America (U.S.A. or USA), commonly known as the United States (U.S. or US) or America, is a country comprising 50 states, a federal district, five major self-governing territories, and various possessions. At 3.8 million square miles (9.8 million km2), the United States is the world's third or fourth largest country by total area and is slightly smaller than the entire continent of Europe. With a population of over 327 million people, the U.S. is the third most populous country. The capital is Washington, D.C., and the most populous city is New York City. Most of the country is located contiguously in North America between Canada and Mexico.",
-  "partOf" : "https://w3id.org/okn/i/mint/America",
+        response = '''
+{
+  "@graph" : [ {
+    "@id" : "https://w3id.org/okn/i/mint/America",
+    "@type" : "https://w3id.org/okn/o/sdm#Region"
+  }, {
+    "@id" : "https://w3id.org/okn/i/mint/United_States",
+    "@type" : "https://w3id.org/okn/o/sdm#Region",
+    "label" : "United States of America",
+    "description" : "The United States of America (U.S.A. or USA), commonly known as the United States (U.S. or US) or America, is a country comprising 50 states, a federal district, five major self-governing territories, and various possessions. At 3.8 million square miles (9.8 million km2), the United States is the world's third or fourth largest country by total area and is slightly smaller than the entire continent of Europe. With a population of over 327 million people, the U.S. is the third most populous country. The capital is Washington, D.C., and the most populous city is New York City. Most of the country is located contiguously in North America between Canada and Mexico.",
+    "partOf" : "https://w3id.org/okn/i/mint/America"
+  }, {
+    "@id" : "https://w3id.org/okn/o/sdm#Region",
+    "@type" : "http://www.w3.org/2002/07/owl#Class"
+  } ],
   "@context" : {
     "partOf" : {
       "@id" : "https://w3id.org/okn/o/sdm#partOf",
@@ -165,10 +174,10 @@ class TestQueryManager(unittest.TestCase):
     "label" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#label"
     },
-    "sd" : "https://w3id.org/okn/o/sd#",
     "rdfs" : "http://www.w3.org/2000/01/rdf-schema#"
   }
-}'''
+}
+'''
 
         framed = self.query_manager.frame_results(response, owl_class_uri, owl_resource_uri)
         self.assertEqual(owl_resource_uri, framed[0]["id"])


### PR DESCRIPTION
The SPARQL returns the context and the graph. Then, we don't need to load the whole context file.

Example: Pink Floyd. You can see the context is smaller than the whole context.

```json
{ "@context": {
    "m": { "@id": "http://dbpedia.org/property/m", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "background": { "@id": "http://dbpedia.org/ontology/background" },
    "width": { "@id": "http://dbpedia.org/property/width", "@type": "http://dbpedia.org/datatype/perCent" },
    "s": { "@id": "http://dbpedia.org/property/s", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "wikiPageID": { "@id": "http://dbpedia.org/ontology/wikiPageID" },
    "wikiPageRevisionID": { "@id": "http://dbpedia.org/ontology/wikiPageRevisionID" },
    "b": { "@id": "http://dbpedia.org/property/b", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "voy": { "@id": "http://dbpedia.org/property/voy", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "genre": { "@id": "http://dbpedia.org/ontology/genre", "@type": "@id" },
    "hypernym": { "@id": "http://purl.org/linguistics/gold/hypernym", "@type": "@id" },
    "caption": { "@id": "http://dbpedia.org/property/caption", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "quote": { "@id": "http://dbpedia.org/property/quote", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "d": { "@id": "http://dbpedia.org/property/d", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "wikiPageExternalLink": { "@id": "http://dbpedia.org/ontology/wikiPageExternalLink", "@type": "@id" },
    "mw": { "@id": "http://dbpedia.org/property/mw", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "activeYearsStartYear": { "@id": "http://dbpedia.org/ontology/activeYearsStartYear", "@type": "http://www.w3.org/2001/XMLSchema#gYear" },
    "isPrimaryTopicOf": { "@id": "http://xmlns.com/foaf/0.1/isPrimaryTopicOf", "@type": "@id" },
    "seeAlso": { "@id": "http://www.w3.org/2000/01/rdf-schema#seeAlso", "@type": "@id" },
    "align": { "@id": "http://dbpedia.org/property/align", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "comment": { "@id": "http://www.w3.org/2000/01/rdf-schema#comment" },
    "imdbId": { "@id": "http://dbpedia.org/ontology/imdbId" },
    "wordnet_type": { "@id": "http://dbpedia.org/property/wordnet_type", "@type": "@id" },
    "sameAs": { "@id": "http://www.w3.org/2002/07/owl#sameAs", "@type": "@id" },
    "homepage": { "@id": "http://xmlns.com/foaf/0.1/homepage", "@type": "@id" },
    "alt": { "@id": "http://dbpedia.org/property/alt", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "style": { "@id": "http://dbpedia.org/property/style", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "hometown": { "@id": "http://dbpedia.org/ontology/hometown", "@type": "@id" },
    "wikt": { "@id": "http://dbpedia.org/property/wikt", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "subject": { "@id": "http://purl.org/dc/terms/subject", "@type": "@id" },
    "name": { "@id": "http://xmlns.com/foaf/0.1/name" },
    "activeYearsEndYear": { "@id": "http://dbpedia.org/ontology/activeYearsEndYear", "@type": "http://www.w3.org/2001/XMLSchema#gYear" },
    "abstract": { "@id": "http://dbpedia.org/ontology/abstract" },
    "formerBandMember": { "@id": "http://dbpedia.org/ontology/formerBandMember", "@type": "@id" },
    "label": { "@id": "http://www.w3.org/2000/01/rdf-schema#label" },
    "n": { "@id": "http://dbpedia.org/property/n", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "source": { "@id": "http://dbpedia.org/property/source", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "recordLabel": { "@id": "http://dbpedia.org/ontology/recordLabel", "@type": "@id" },
    "wasDerivedFrom": { "@id": "http://www.w3.org/ns/prov#wasDerivedFrom", "@type": "@id" },
    "species": { "@id": "http://dbpedia.org/property/species", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" },
    "v": { "@id": "http://dbpedia.org/property/v", "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString" } },
```